### PR TITLE
Remove Babel - ECMA13

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-    "presets": ["@babel/env"],
-    "plugins": [
-        "@babel/plugin-syntax-class-properties"
-    ]
-}
-

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,18 +1,16 @@
 {
     "extends": "eslint:recommended",
     "root": true,
-    "parser": "@babel/eslint-parser",
-    "parserOptions": {
-        "ecmaVersion": 2018,
-        "babelOptions": {
-            "configFile": "./.babelrc"
-        }
-    },
     "env": {
-        "node": true,
-        "es6": true
+        "node": true
     },
-    "plugins": [ "node", "@babel" ],
+    "globals": {
+        "Map": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 13
+    },
+    "plugins": [ "node" ],
     "rules": {
         "no-console": 0,
         "arrow-parens": [ "error", "always" ],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - ready_for_review
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+
+            - uses: actions/setup-node@v2
+              with:
+                node-version: '16'
+
+            - run: npm install
+
+            - run: npm run lint
+
+            - run: npm test
+

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     Schema: require('./lib/schema'),
     Err: require('./lib/error')

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @class
  */

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { Validator } = require('express-json-validator-middleware');
 const $RefParser = require('json-schema-ref-parser');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
         "tape": "^5.3.1"
     },
     "devDependencies": {
-        "@babel/eslint-parser": "^7.15.7",
-        "@babel/eslint-plugin": "^7.14.5",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/preset-env": "^7.15.6",
         "eslint": "^8.0.1",
         "eslint-plugin-node": "^11.0.0"
     }

--- a/routes/schema.js
+++ b/routes/schema.js
@@ -1,3 +1,4 @@
+'use strict';
 const Err = require('../lib/error');
 
 async function router(schema) {

--- a/test/schema.srv.test.js
+++ b/test/schema.srv.test.js
@@ -52,6 +52,12 @@ test('GET: api/schema?method=FAKE', async (t) => {
             status: 400,
             message: 'validation error',
             messages: [{
+                keyword: 'enum',
+                dataPath: '.method',
+                schemaPath: '#/properties/method/enum',
+                params: {
+                    allowedValues: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+                },
                 message: 'should be equal to one of the allowed values'
             }]
         });

--- a/test/schema.srv.test.js
+++ b/test/schema.srv.test.js
@@ -1,3 +1,4 @@
+'use strict';
 const test = require('tape');
 const express = require('express');
 const { Schema } = require('../');

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1,3 +1,4 @@
+'use strict';
 const fs = require('fs');
 const path = require('path');
 const test = require('tape');


### PR DESCRIPTION
### Context

ESLint now natively supports parsing ECMA 13, which supports static class variables - the reason why we were having to use babel.