### PR TITLE
Auto Documentation [Experimental]

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,0 +1,36 @@
+/**
+ * @class Docs
+ */
+export default class Docs extends Array {
+    push(parsed, schemas) {
+        const apiParams = [];
+        for (const key in schemas) {
+            if (key[0] === ':') {
+                apiParams.push(`* @apiParam {${schemas[key]}} ${key.slice(1)} param`);
+            }
+        }
+
+        super.push(
+            `
+                /**
+                 * @api {${parsed[0].toLowerCase()}} ${parsed[1]} ${schemas.name || parsed.join(' ')}
+                 * @apiVersion ${schemas.version || '1.0.0'}
+                 * @apiName ${parsed.join('-')}
+                 * @apiGroup ${schemas.group || 'Default'}
+                 * @apiPermission ${schemas.auth || 'Unknown'}
+                 *
+                 * @apidescription
+                 *   ${schemas.description || 'No Description'}
+                 *
+                 ${apiParams.join('\n')}
+                 *
+                 * ${schemas.query_url ? `@apiSchema (Query) {jsonschema=${schemas.query_url}} apiParam` : ''}
+                 * ${schemas.body_url ? `@apiSchema (Body) {jsonschema=${schemas.body_url}} apiParam` : ''}
+                 * ${schemas.res_url ? `@apiSchema {jsonschema=${schemas.res_url}} apiSuccess` : ''}
+                 */
+            `.split('\n')
+                .map((l) => l.trim())
+                .join('\n')
+        );
+    }
+}

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -7,6 +7,7 @@ import bodyparser from 'body-parser';
 
 import SchemaRoute from '../routes/schema.js';
 import Param from './param.js';
+import Docs from './docs.js';
 import Middleware from './middleware.js';
 
 /**
@@ -17,6 +18,8 @@ import Middleware from './middleware.js';
  * @param {String} opts.schemas Schemas Path
  * @param {boolean|string} [opts.logging=true] disable logging with false
  * @param {number} [opts.limit=50] body size limit in mb
+ *
+ * @param {URL} [opts.apidoc] apidoc file location
  */
 export default class Schemas {
     constructor(router, opts = {}) {
@@ -45,6 +48,8 @@ export default class Schemas {
 
         this.schemas = new Map();
         this.validate = this.validator.validate;
+
+        this.docs = new Docs();
     }
 
     async api() {
@@ -121,12 +126,16 @@ export default class Schemas {
         for (const type of ['body', 'query', 'res']) {
             if (!schemas[type]) continue;
 
+            // TODO: Write schemas to a tmp directory so blueprints & main schemas are in the same place
+            schemas[`${type}_url`] = '../schema/' + schemas[type];
             try {
                 schemas[type] = await $RefParser.dereference((new URL(`../schema/${schemas[type]}`, import.meta.url)).pathname);
             } catch (err) {
                 schemas[type] = await $RefParser.dereference(`${this.schemas_path}/${schemas[type]}`);
             }
         }
+
+        this.docs.push(parsed, schemas);
 
         this.schemas.set(parsed.join(' '), schemas);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -187,7 +187,11 @@ export default class Schemas {
         if (!schema.body) schema.body = null;
         if (!schema.res) schema.res = null;
 
-        return schema;
+        return {
+            query: schema.query,
+            body: schema.body,
+            res: schema.res
+        };
     }
 
     /**


### PR DESCRIPTION
### Context

Add experimental support automatically generating APIDocs directly from schema definitions.

Adds the following properties:
- `name` (Optional) The human readable name of the API
- `group` (Optional) The grouping the API should be part of
- `version` (Optional) The version of the API the documentation is part of
- `description` (Optional) Human readable description of what the API does
- `auth` (Optional) What type of auth is required to use the API

While all properties are optional, documentation generated without them will be very minimal/rough at best.